### PR TITLE
Correção de teste do método enableShutdownHooks no service do Prisma

### DIFF
--- a/tests/unit/prisma/prisma.service.spec.ts
+++ b/tests/unit/prisma/prisma.service.spec.ts
@@ -32,6 +32,8 @@ describe('PrismaService', () => {
       const onPrismaClientSpy = jest.fn();
       const appMock = {} as INestApplication;
 
+      prismaService.$on = onPrismaClientSpy;
+
       await prismaService.enableShutdownHooks(appMock);
 
       expect(onPrismaClientSpy).toHaveBeenCalledWith(


### PR DESCRIPTION
**Contexto:** o teste do método _enableShutdownHooks_ estava quebrando por conta da não implementação do mock do método _$on_ utilizando dentro do método testado. 

**Desenvolvimento:** o mock foi linkado com seu método.