### PR TITLE
Refatoração de responsável principal

### DIFF
--- a/prisma/migrations/20220522132635_main_responsible/migration.sql
+++ b/prisma/migrations/20220522132635_main_responsible/migration.sql
@@ -1,0 +1,15 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `mainResponsibleId` on the `Enterprise` table. All the data in the column will be lost.
+  - You are about to drop the column `mainResponsibleId` on the `Location` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "Enterprise" DROP COLUMN "mainResponsibleId";
+
+-- AlterTable
+ALTER TABLE "Location" DROP COLUMN "mainResponsibleId";
+
+-- AlterTable
+ALTER TABLE "Responsible" ADD COLUMN     "isMain" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,7 +25,6 @@ model Enterprise {
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId String
   responsibleId String
-  mainResponsibleId String
 
   locations Location[]
   responsibles Responsible[]
@@ -37,7 +36,6 @@ model Location {
   address String
   enterprise Enterprise @relation(fields: [enterpriseId], references: [id], onDelete: Cascade)
   enterpriseId String
-  mainResponsibleId String
 
   tickets Ticket[]
   responsibles Responsible[]
@@ -48,6 +46,7 @@ model Responsible {
   name String
   telephone String
   address String
+  isMain Boolean @default(false)
   enterprise Enterprise? @relation(fields: [enterpriseId], references: [id], onDelete: Cascade)
   location Location? @relation(fields: [locationId], references: [id], onDelete: Cascade)
   enterpriseId String


### PR DESCRIPTION
**Contexto:** um responsável principal estava ou em _Enterprise_ ou em _Location_ como uma gambiarra. Para melhorar isso, quem vai dizer quem se é responsável é o próprio _Responsible_.

**Desenvolvimento:** o schema foi alterado, retirando o _mainResponsibleId_ dos models de _Enterprise_ e _Location_, e adicionada a coluna _isMain_ de tipo booleano.