### PR TITLE
Criar service de responsáveis

### DIFF
--- a/prisma/migrations/20220522135347_refactor_responsible_address/migration.sql
+++ b/prisma/migrations/20220522135347_refactor_responsible_address/migration.sql
@@ -1,0 +1,18 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `address` on the `Responsible` table. All the data in the column will be lost.
+  - Added the required column `city` to the `Responsible` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `neighborhood` to the `Responsible` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `state` to the `Responsible` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `street` to the `Responsible` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `zipcode` to the `Responsible` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Responsible" DROP COLUMN "address",
+ADD COLUMN     "city" TEXT NOT NULL,
+ADD COLUMN     "neighborhood" TEXT NOT NULL,
+ADD COLUMN     "state" TEXT NOT NULL,
+ADD COLUMN     "street" TEXT NOT NULL,
+ADD COLUMN     "zipcode" TEXT NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,7 +45,11 @@ model Responsible {
   id String @default(uuid()) @id
   name String
   telephone String
-  address String
+  zipcode String
+  street String
+  neighborhood String
+  city String
+  state String
   isMain Boolean @default(false)
   enterprise Enterprise? @relation(fields: [enterpriseId], references: [id], onDelete: Cascade)
   location Location? @relation(fields: [locationId], references: [id], onDelete: Cascade)

--- a/src/responsible/responsible.service.ts
+++ b/src/responsible/responsible.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+import { Responsible } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+
+export interface IResponsibleData {
+  name: string;
+  telephone: string;
+  zipcode: string;
+  street: string;
+  neighborhood: string;
+  city: string;
+  state: string;
+  isMain: boolean;
+}
+
+@Injectable()
+export class ResponsibleService {
+  constructor(private prismaService: PrismaService) {}
+
+  async create(data: IResponsibleData): Promise<Responsible> {
+    return this.prismaService.responsible.create({
+      data,
+    });
+  }
+
+  async findAll(): Promise<Responsible[]> {
+    const responsibles = await this.prismaService.responsible.findMany();
+
+    return responsibles;
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.prismaService.responsible.delete({
+      where: {
+        id,
+      },
+    });
+  }
+}

--- a/tests/unit/responsible/responsible.service.spec.ts
+++ b/tests/unit/responsible/responsible.service.spec.ts
@@ -1,0 +1,88 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from '../../../src/prisma/prisma.service';
+import { ResponsibleService } from '../../../src/responsible/responsible.service';
+
+describe('ResponsibleService', () => {
+  let responsibleService: ResponsibleService;
+  let prismaService: PrismaService;
+
+  const createResponsibleMock = jest.fn();
+  const findManyResponsibleMock = jest.fn();
+  const prismaServiceMock = {
+    responsible: {
+      create: createResponsibleMock,
+      findMany: findManyResponsibleMock,
+      delete: jest.fn(),
+    },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ResponsibleService,
+        {
+          provide: PrismaService,
+          useValue: prismaServiceMock,
+        },
+      ],
+    }).compile();
+
+    responsibleService = module.get<ResponsibleService>(ResponsibleService);
+    prismaService = module.get<PrismaService>(PrismaService);
+  });
+
+  it('should be defined', () => {
+    expect(responsibleService).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('Should create a responsible', async () => {
+      const responsibleDataMock = {
+        name: 'name',
+        telephone: 'telephone',
+        zipcode: 'zipcode',
+        street: 'street',
+        neighborhood: 'neighborhood',
+        city: 'city',
+        state: 'state',
+        isMain: true,
+      };
+
+      createResponsibleMock.mockImplementationOnce(() => 'new responsible');
+
+      const result = await responsibleService.create(responsibleDataMock);
+
+      expect(prismaService.responsible.create).toHaveBeenCalledWith({
+        data: responsibleDataMock,
+      });
+      expect(result).toBe('new responsible');
+    });
+  });
+
+  describe('findAll', () => {
+    it('Should return all responsibles', async () => {
+      findManyResponsibleMock.mockImplementationOnce(() => [
+        'responsible 1',
+        'responsible 2',
+        'responsible 3',
+      ]);
+
+      const result = await responsibleService.findAll();
+
+      expect(prismaService.responsible.findMany).toHaveBeenCalled();
+      expect(result).toHaveLength(3);
+    });
+  });
+
+  describe('delete', () => {
+    it('Should delete a responsible', async () => {
+      await responsibleService.delete('id');
+
+      expect(prismaService.responsible.delete).toHaveBeenCalledWith({
+        where: {
+          id: 'id',
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
**Contexto:** um responsável estará linkado com empresas e locais. Inicialmente não terá endpoints para esta entidade do sistema.

**Desenvolvimento:** foi adicionado o service de responsáveis com métodos para criar, pegar todos e deletar.