### PR TITLE
Fluxo de retornar uma empresa pelo id

### DIFF
--- a/src/enterprises/enterprises.controller.ts
+++ b/src/enterprises/enterprises.controller.ts
@@ -32,6 +32,7 @@ export class EnterprisesController {
     return this.enterprisesService.findAll();
   }
 
+  @UseGuards(JwtAuthGuard)
   @Get(':id')
   async findById(@Param('id') id: string, @Res() response: Response) {
     const enterprise = await this.enterprisesService.findById(id);

--- a/src/enterprises/enterprises.controller.ts
+++ b/src/enterprises/enterprises.controller.ts
@@ -7,11 +7,14 @@ import {
   Param,
   Delete,
   UseGuards,
+  Res,
+  HttpStatus,
 } from '@nestjs/common';
 import { EnterprisesService } from './enterprises.service';
 import { CreateEnterpriseDto } from './dto/create-enterprise.dto';
 import { UpdateEnterpriseDto } from './dto/update-enterprise.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { Response } from 'express';
 
 @Controller('enterprises')
 export class EnterprisesController {
@@ -30,8 +33,16 @@ export class EnterprisesController {
   }
 
   @Get(':id')
-  findById(@Param('id') id: string) {
-    return this.enterprisesService.findById(id);
+  async findById(@Param('id') id: string, @Res() response: Response) {
+    const enterprise = await this.enterprisesService.findById(id);
+
+    if (!enterprise) {
+      return response
+        .status(HttpStatus.NOT_FOUND)
+        .json({ message: 'Enterprise not found' });
+    }
+
+    return response.json(enterprise);
   }
 
   @Patch(':id')

--- a/src/enterprises/enterprises.service.ts
+++ b/src/enterprises/enterprises.service.ts
@@ -33,8 +33,18 @@ export class EnterprisesService {
     return this.prismaService.enterprise.findMany();
   }
 
-  findById(id: string) {
-    return `This action returns a #${id} enterprise`;
+  async findById(id: string): Promise<Enterprise | null> {
+    const enterprise = await this.prismaService.enterprise.findUnique({
+      where: {
+        id,
+      },
+    });
+
+    if (!enterprise) {
+      return null;
+    }
+
+    return enterprise;
   }
 
   update(id: string, updateEnterpriseDto: UpdateEnterpriseDto) {

--- a/tests/unit/enterprises/enterprises.controller.spec.ts
+++ b/tests/unit/enterprises/enterprises.controller.spec.ts
@@ -1,4 +1,6 @@
+import { HttpStatus } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { Response } from 'express';
 import { EnterprisesController } from '../../../src/enterprises/enterprises.controller';
 import { EnterprisesService } from '../../../src/enterprises/enterprises.service';
 
@@ -7,11 +9,15 @@ describe('EnterprisesController', () => {
   let enterprisesService: EnterprisesService;
 
   const findAllMock = jest.fn();
+  const findByIdMock = jest.fn();
 
   const enterprisesServiceMock = {
     create: jest.fn(),
     findAll: findAllMock,
+    findById: findByIdMock,
   };
+
+  const responseMock = {} as Response;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -85,6 +91,33 @@ describe('EnterprisesController', () => {
 
       expect(enterprisesService.findAll).toHaveBeenCalled();
       expect(result).toHaveLength(4);
+    });
+  });
+
+  describe('findById', () => {
+    const responseJsonMock = jest.fn();
+    responseMock.json = responseJsonMock;
+    responseMock.status = jest.fn().mockReturnValue({
+      json: responseJsonMock,
+    });
+
+    it('Should return when the enterprise exists', async () => {
+      findByIdMock.mockImplementationOnce(() => 'enterprise');
+
+      await enterprisesController.findById('id', responseMock);
+
+      expect(responseMock.json).toHaveBeenCalledWith('enterprise');
+    });
+
+    it('Should return a error message when the enterprise not exists', async () => {
+      findByIdMock.mockImplementationOnce(() => null);
+
+      await enterprisesController.findById('id', responseMock);
+
+      expect(responseMock.status).toHaveBeenCalledWith(HttpStatus.NOT_FOUND);
+      expect(responseMock.json).toHaveBeenCalledWith({
+        message: 'Enterprise not found',
+      });
     });
   });
 });

--- a/tests/unit/enterprises/enterprises.service.spec.ts
+++ b/tests/unit/enterprises/enterprises.service.spec.ts
@@ -7,11 +7,13 @@ describe('EnterprisesService', () => {
   let prismaService: PrismaService;
 
   const findManyMock = jest.fn();
+  const findUniqueMock = jest.fn();
 
   const prismaServiceMock = {
     enterprise: {
       create: jest.fn(),
       findMany: findManyMock,
+      findUnique: findUniqueMock,
     },
   };
 
@@ -92,6 +94,34 @@ describe('EnterprisesService', () => {
 
       expect(prismaService.enterprise.findMany).toHaveBeenCalled();
       expect(result).toHaveLength(4);
+    });
+  });
+
+  describe('findById', () => {
+    it('Should return an enterprise when exists', async () => {
+      findUniqueMock.mockImplementationOnce(() => 'enterprise');
+
+      const result = await enterpriseService.findById('id');
+
+      expect(prismaService.enterprise.findUnique).toHaveBeenCalledWith({
+        where: {
+          id: 'id',
+        },
+      });
+      expect(result).toBe('enterprise');
+    });
+
+    it('Should return an enterprise when exists', async () => {
+      findUniqueMock.mockImplementationOnce(() => false);
+
+      const result = await enterpriseService.findById('id');
+
+      expect(prismaService.enterprise.findUnique).toHaveBeenCalledWith({
+        where: {
+          id: 'id',
+        },
+      });
+      expect(result).toBe(null);
     });
   });
 });


### PR DESCRIPTION
**Contexto:** retornar os dados de uma empresa pelo seu id.

**Desenvolvimento:** os métodos de pegar uma empresa pelo id foram implementados no service e no controller. O endpoint também foi protegido com autenticação JWT.