### PR TITLE
Adicionar locais e responsáveis de uma empresa no endpoint por id

### DIFF
--- a/src/enterprises/enterprises.service.ts
+++ b/src/enterprises/enterprises.service.ts
@@ -38,6 +38,10 @@ export class EnterprisesService {
       where: {
         id,
       },
+      include: {
+        locations: true,
+        responsibles: true,
+      },
     });
 
     if (!enterprise) {

--- a/tests/unit/enterprises/enterprises.service.spec.ts
+++ b/tests/unit/enterprises/enterprises.service.spec.ts
@@ -113,11 +113,15 @@ describe('EnterprisesService', () => {
         where: {
           id: 'id',
         },
+        include: {
+          locations: true,
+          responsibles: true,
+        },
       });
       expect(result).toBe('enterprise');
     });
 
-    it('Should return an enterprise when exists', async () => {
+    it('Should return null when an enterprise not exists', async () => {
       findUniqueMock.mockImplementationOnce(() => false);
 
       const result = await enterpriseService.findById('id');
@@ -125,6 +129,10 @@ describe('EnterprisesService', () => {
       expect(prismaService.enterprise.findUnique).toHaveBeenCalledWith({
         where: {
           id: 'id',
+        },
+        include: {
+          locations: true,
+          responsibles: true,
         },
       });
       expect(result).toBe(null);


### PR DESCRIPTION
**Contexto:** para facilitar a visualização dos dados pelo front, viu-se que seria melhor já retornar os locais e responsáveis de uma empresa específica.

**Desenvolvimento:** os locais e responsáveis foram adicionados ao retorno do método que pega uma empresa por id no service de empresas.