### PR TITLE
Remover senha do retorno do endpoint que retorna dados do usuário pelo id

### DIFF
--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -4,6 +4,12 @@ import { PrismaService } from '../prisma/prisma.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 
+export interface IUserWithoutPassword {
+  id: string;
+  username: string;
+  name: string;
+}
+
 @Injectable()
 export class UsersService {
   constructor(private prismaService: PrismaService) {}
@@ -24,10 +30,15 @@ export class UsersService {
     return `This action returns all users`;
   }
 
-  async findById(id: string): Promise<User | null> {
+  async findById(id: string): Promise<IUserWithoutPassword | null> {
     const user = await this.prismaService.user.findUnique({
       where: {
         id,
+      },
+      select: {
+        id: true,
+        username: true,
+        name: true,
       },
     });
 

--- a/tests/unit/users/users.service.spec.ts
+++ b/tests/unit/users/users.service.spec.ts
@@ -60,7 +60,11 @@ describe('UsersService', () => {
 
   describe('findById', () => {
     it('Should return the user when exists', async () => {
-      findUniqueMock.mockResolvedValueOnce('user');
+      findUniqueMock.mockResolvedValueOnce({
+        id: 'id',
+        username: 'username',
+        name: 'name',
+      });
 
       const user = await usersService.findById('id');
 
@@ -68,8 +72,17 @@ describe('UsersService', () => {
         where: {
           id: 'id',
         },
+        select: {
+          id: true,
+          username: true,
+          name: true,
+        },
       });
-      expect(user).toBe('user');
+      expect(user).toEqual({
+        id: 'id',
+        username: 'username',
+        name: 'name',
+      });
     });
 
     it('Should return null when the user not exists', async () => {
@@ -80,6 +93,11 @@ describe('UsersService', () => {
       expect(findUniqueMock).toHaveBeenCalledWith({
         where: {
           id: 'id',
+        },
+        select: {
+          id: true,
+          username: true,
+          name: true,
         },
       });
       expect(user).toBeFalsy();


### PR DESCRIPTION
**Contexto:** para não retornar dados desnecessários, fez-se necessário remover a senha do retorno do endpoint que pega dados do usuário pelo id.

**Desenvolvimento:** foi adicionado um select na query feita no Prisma no service de usuário que seleciona todos os campos, menos a senha.