### PR TITLE
Corrigir erros de importação no teste e2e do app

### DIFF
--- a/src/locations/locations.module.ts
+++ b/src/locations/locations.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { LocationsService } from './locations.service';
 import { LocationsController } from './locations.controller';
-import { PrismaService } from 'src/prisma/prisma.service';
+import { PrismaService } from '../prisma/prisma.service';
 
 @Module({
   controllers: [LocationsController],

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -16,7 +16,7 @@ import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { HashManager } from '../lib/HashManager';
-import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 @Controller('users')
 export class UsersController {

--- a/tests/unit/auth/auth.controller.spec.ts
+++ b/tests/unit/auth/auth.controller.spec.ts
@@ -1,5 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { AuthService } from '../../../src/auth/auth.service';
 import { AuthController } from '../../../src/auth/auth.controller';
+import { UsersService } from '../../../src/users/users.service';
+import { PrismaService } from '../../../src/prisma/prisma.service';
+import { JwtService } from '@nestjs/jwt';
 
 describe('AuthController', () => {
   let controller: AuthController;
@@ -7,6 +11,7 @@ describe('AuthController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AuthController],
+      providers: [AuthService, JwtService, PrismaService, UsersService],
     }).compile();
 
     controller = module.get<AuthController>(AuthController);


### PR DESCRIPTION
**Contexto:** o teste E2E do app estava quebrando por problemas com imports dentro dos arquivos que fazem parte do teste.

**Desenvolvimento:** os imports foram corrigidos. Durante a execução dos testes foi encontrado outro teste que estava quebrando e o mesmo foi corrigido. Se tratava do teste do controller de autenticação, que não foi feito, apenas criado com a criação do resource _auth_.


